### PR TITLE
Follow up to wikipedia popups

### DIFF
--- a/app/components/Article/article.css
+++ b/app/components/Article/article.css
@@ -157,6 +157,9 @@ article .link-popup {
   z-index: 4;
   width: auto;
   min-width: 350px;
+  box-shadow:
+    0 30px 90px -20px rgba(0, 0, 0, 0.3),
+    0 0 0 1px var(--border);
 }
 
 /* Right image layout - image on the right side */


### PR DESCRIPTION
Fix https://github.com/StampyAI/stampy-ui/issues/1009

I also implemented more prominent shadow boxes to match the wikipedia style

Before:
<img width="635" height="360" alt="image" src="https://github.com/user-attachments/assets/e0fbeb72-f9be-4baf-a134-ab91e16bd9bd" />

After:
<img width="635" height="360" alt="image" src="https://github.com/user-attachments/assets/d8bfbd86-1586-42f7-a8cd-4df537beafd4" />
