### PR TITLE
Show regular cursor above Article button in Navbar

### DIFF
--- a/app/components/Nav/nav.css
+++ b/app/components/Nav/nav.css
@@ -31,3 +31,7 @@
   object-fit: contain;
   object-position: center;
 }
+
+#showArticles .top-menu-link {
+  cursor: default;
+}


### PR DESCRIPTION
fix https://github.com/StampyAI/stampy-ui/issues/468

Unfortunately, my print-screen utility hides my cursor so I can't easily show screenshots, but works as expected, and buttons on the right are not affected.