### PR TITLE
feat(categories.$.tsx): use different meta tags than root

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -22,6 +22,7 @@ import {CachedObjectsProvider} from '~/hooks/useCachedObjects'
 import {useTheme} from '~/hooks/theme'
 import {loadQuestionDetail} from '~/server-utils/stampy'
 import GlobalBanners from './components/GlobalBanners'
+import {createMetaTags} from '~/utils/meta'
 
 /*
  * Transform the given text into a meta header format.
@@ -61,30 +62,18 @@ const fetchQuestion = async (request: Request) => {
 
 const TITLE = 'AISafety.info'
 const DESCRIPTION = 'AI safety FAQ'
-const twitterCreator = '@stampyai'
 export const meta: MetaFunction<typeof loader> = ({data = {} as any}) => {
   const title = makeSocialPreviewText(data.question?.title, TITLE, 150)
   const description = makeSocialPreviewText(data.question?.text, DESCRIPTION)
   const url = data.url ? new URL(data.url) : null
   const logo = url ? `${url.origin}/aisafety-logo.png` : '/aisafety-logo.png'
-  return [
-    {title},
-    {name: 'description', content: description},
-    {property: 'og:url', content: data.url},
-    {property: 'og:type', content: 'article'},
-    {property: 'og:title', content: title},
-    {property: 'og:description', content: description},
-    {property: 'og:image', content: logo},
-    {property: 'og:image:type', content: 'image/png'},
-    {property: 'og:image:width', content: '1200'},
-    {property: 'og:image:height', content: '630'},
-    {name: 'twitter:card', content: 'summary_large_image'},
-    {name: 'twitter:title', content: title},
-    {name: 'twitter:description', content: description},
-    {name: 'twitter:image', content: logo},
-    {name: 'twitter:creator', content: twitterCreator},
-    {name: 'twitter:url', content: data.url},
-  ]
+
+  return createMetaTags({
+    title,
+    description,
+    url: data.url,
+    image: logo,
+  })
 }
 
 export const links: LinksFunction = () => {

--- a/app/routes/categories.$.tsx
+++ b/app/routes/categories.$.tsx
@@ -1,5 +1,6 @@
 import {useState, useEffect} from 'react'
 import {useLoaderData} from '@remix-run/react'
+import {MetaFunction} from '@remix-run/cloudflare'
 import Page from '~/components/Page'
 import ListTable from '~/components/Table'
 import {loader} from '~/routes/categories.all'
@@ -7,7 +8,18 @@ import {CategoriesNav} from '~/components/CategoriesNav/CategoriesNav'
 import type {Tag as TagType} from '~/server-utils/stampy'
 import useIsMobile from '~/hooks/isMobile'
 import {CategoriesPage} from '~/components/CategoriesNav/Page'
+import {createMetaTags} from '~/utils/meta'
 export {loader}
+
+export const meta: MetaFunction<typeof loader> = ({data}) => {
+  const categoryName = data?.data?.currentTag?.name
+  const title = categoryName ? `${categoryName} - AISafety.info` : 'Categories - AISafety.info'
+  const description = categoryName
+    ? `Browse AI safety questions related to ${categoryName}`
+    : 'Browse AI safety questions by category'
+
+  return createMetaTags({title, description})
+}
 
 export const sortFuncs = {
   alphabetically: (a: TagType, b: TagType) =>

--- a/app/utils/meta.ts
+++ b/app/utils/meta.ts
@@ -1,0 +1,32 @@
+export const createMetaTags = ({
+  title,
+  description,
+  url,
+  image,
+}: {
+  title: string
+  description: string
+  url?: string
+  image?: string
+}) => {
+  const logo = image || '/aisafety-logo.png'
+
+  return [
+    {title},
+    {name: 'description', content: description},
+    {property: 'og:url', content: url},
+    {property: 'og:type', content: 'article'},
+    {property: 'og:title', content: title},
+    {property: 'og:description', content: description},
+    {property: 'og:image', content: logo},
+    {property: 'og:image:type', content: 'image/png'},
+    {property: 'og:image:width', content: '1200'},
+    {property: 'og:image:height', content: '630'},
+    {name: 'twitter:card', content: 'summary_large_image'},
+    {name: 'twitter:title', content: title},
+    {name: 'twitter:description', content: description},
+    {name: 'twitter:image', content: logo},
+    {name: 'twitter:creator', content: '@stampyai'},
+    {name: 'twitter:url', content: url},
+  ]
+}


### PR DESCRIPTION
## Problem
All category pages (e.g., /categories/9/Superintelligence) were showing the same generic title "AISafety.info" instead of unique, descriptive titles. This was flagged by an SEO scan as a problem for search engine optimization.

## Solution
- Added a meta export to categories.$.tsx that generates dynamic titles based on the category name (e.g., "Superintelligence - AISafety.info")
- Created a shared meta.ts utility to ensure consistent meta tag structure across all routes
- Refactored root.tsx to use the same shared utility, reducing code duplication

## Tests
A category page loaded with different `meta` as expected
<img width="1077" height="328" alt="image" src="https://github.com/user-attachments/assets/3f06af55-5e9f-4cb7-a4ae-713fba22ca5a" />
