### PR TITLE
specific titles and descriptions for how can I help pages

### DIFF
--- a/app/routes/how-can-i-help._index.tsx
+++ b/app/routes/how-can-i-help._index.tsx
@@ -7,7 +7,8 @@ import {createMetaTags} from '~/utils/meta'
 export const meta: MetaFunction = () => {
   return createMetaTags({
     title: 'How Can I Help? - AISafety.info',
-    description: 'The AI safety movement is still relatively new, and your actions could have significant impact. Explore ways to contribute to AI safety.',
+    description:
+      'The AI safety movement is still relatively new, and your actions could have significant impact. Explore ways to contribute to AI safety.',
   })
 }
 

--- a/app/routes/how-can-i-help.career.tsx
+++ b/app/routes/how-can-i-help.career.tsx
@@ -12,7 +12,8 @@ import {createMetaTags} from '~/utils/meta'
 export const meta: MetaFunction = () => {
   return createMetaTags({
     title: 'Start a Career in AI Safety - How Can I Help? - AISafety.info',
-    description: 'Explore career paths in AI alignment research, AI governance & policy, and AI safety field-building. Find your place in making AI safer.',
+    description:
+      'Explore career paths in AI alignment research, AI governance & policy, and AI safety field-building. Find your place in making AI safer.',
   })
 }
 

--- a/app/routes/how-can-i-help.community.tsx
+++ b/app/routes/how-can-i-help.community.tsx
@@ -6,7 +6,8 @@ import {createMetaTags} from '~/utils/meta'
 export const meta: MetaFunction = () => {
   return createMetaTags({
     title: 'Join a Community - How Can I Help? - AISafety.info',
-    description: 'Connect with others interested in AI safety through in-person meetups and online communities worldwide.',
+    description:
+      'Connect with others interested in AI safety through in-person meetups and online communities worldwide.',
   })
 }
 

--- a/app/routes/how-can-i-help.donate.tsx
+++ b/app/routes/how-can-i-help.donate.tsx
@@ -9,7 +9,8 @@ import {createMetaTags} from '~/utils/meta'
 export const meta: MetaFunction = () => {
   return createMetaTags({
     title: 'Donate - How Can I Help? - AISafety.info',
-    description: 'Help advance AI safety through donations. Learn about grantmakers, direct giving, and where your contributions can make the most impact.',
+    description:
+      'Help advance AI safety through donations. Learn about grantmakers, direct giving, and where your contributions can make the most impact.',
   })
 }
 

--- a/app/routes/how-can-i-help.grassroots.tsx
+++ b/app/routes/how-can-i-help.grassroots.tsx
@@ -10,7 +10,8 @@ import {createMetaTags} from '~/utils/meta'
 export const meta: MetaFunction = () => {
   return createMetaTags({
     title: 'Spread the Word & Grassroots Activism - How Can I Help? - AISafety.info',
-    description: 'Raise awareness about AI safety risks through social media, protests, petitions, and conversations. Take action today.',
+    description:
+      'Raise awareness about AI safety risks through social media, protests, petitions, and conversations. Take action today.',
   })
 }
 

--- a/app/routes/how-can-i-help.knowledge.tsx
+++ b/app/routes/how-can-i-help.knowledge.tsx
@@ -11,7 +11,8 @@ import {createMetaTags} from '~/utils/meta'
 export const meta: MetaFunction = () => {
   return createMetaTags({
     title: 'Build Your Knowledge - How Can I Help? - AISafety.info',
-    description: 'Learn about AI safety through courses, videos, podcasts, books, and communities. Start your AI safety education journey.',
+    description:
+      'Learn about AI safety through courses, videos, podcasts, books, and communities. Start your AI safety education journey.',
   })
 }
 

--- a/app/routes/how-can-i-help.volunteer.tsx
+++ b/app/routes/how-can-i-help.volunteer.tsx
@@ -11,7 +11,8 @@ import {createMetaTags} from '~/utils/meta'
 export const meta: MetaFunction = () => {
   return createMetaTags({
     title: 'Volunteer - How Can I Help? - AISafety.info',
-    description: 'Contribute your skills to AI safety projects. Find volunteer opportunities in field-building, communications, and more.',
+    description:
+      'Contribute your skills to AI safety projects. Find volunteer opportunities in field-building, communications, and more.',
   })
 }
 


### PR DESCRIPTION
Further PR to fix #890 .

Gives specify titles and descriptions to each How Can I Help page.

Tested by navigating to the help pages locally

<img width="1344" height="341" alt="image" src="https://github.com/user-attachments/assets/4a49281c-0191-45ea-8c49-56b72a62c1fd" />


