### PR TITLE
Add All Articles page with expandable ToC structure (#1043)

### DIFF
--- a/app/components/ArticlesDropdown/index.tsx
+++ b/app/components/ArticlesDropdown/index.tsx
@@ -3,7 +3,7 @@ import {Link as LinkElem} from '@remix-run/react'
 import type {Tag} from '~/server-utils/stampy'
 import {TOCItem, Category, ADVANCED, BASIC} from '~/routes/questions.toc'
 import {sortFuncs} from '~/routes/categories.$'
-import {questionUrl, tagsUrl, tagUrl} from '~/routesMapper'
+import {questionUrl, tagsUrl, tagUrl, articlesUrl} from '~/routesMapper'
 import Button from '~/components/Button'
 import {Stamp} from '~/components/icons-generated'
 import './dropdown.css'
@@ -83,6 +83,12 @@ export const ArticlesDropdown = ({toc, categories, fullWidth}: ArticlesDropdownP
           className={mobile ? 'padding-bottom-40' : ''}
           hide={hide}
         />
+        <Button
+          action={articlesUrl()}
+          className={['secondary-alt', mobile ? 'margin-top-40' : 'margin-top-32'].join(' ')}
+        >
+          <span onClick={hide}>Browse all articles</span>
+        </Button>
       </div>
       <div className={fullWidth ? '' : 'col-4'}>
         {/*sorted right side*/}

--- a/app/routes/articles.tsx
+++ b/app/routes/articles.tsx
@@ -1,0 +1,149 @@
+import {useLoaderData} from '@remix-run/react'
+import {Link} from '@remix-run/react'
+import {MetaFunction, LoaderFunctionArgs} from '@remix-run/cloudflare'
+import Page from '~/components/Page'
+import {loadToC, TOCItem, BASIC, ADVANCED, Category} from '~/routes/questions.toc'
+import {questionUrl, articlesUrl} from '~/routesMapper'
+import {createMetaTags} from '~/utils/meta'
+import ChevronRight from '~/components/icons-generated/ChevronRight'
+
+export const loader = async ({request}: LoaderFunctionArgs) => {
+  try {
+    return await loadToC(request)
+  } catch (e) {
+    console.error(e)
+    throw new Response('Could not fetch articles', {status: 500})
+  }
+}
+
+export const meta: MetaFunction = () =>
+  createMetaTags({
+    title: 'All Articles - AISafety.info',
+    description: 'Browse all published AI safety articles on AISafety.info',
+    url: articlesUrl(),
+  })
+
+const collectPageIds = (items: TOCItem[], set = new Set<string>()): Set<string> => {
+  items.forEach((item) => {
+    set.add(item.pageid)
+    if (item.children) collectPageIds(item.children, set)
+  })
+  return set
+}
+
+const Chevron = () => <ChevronRight width={12} height={12} className="dropdown-icon" />
+
+const ArticleTree = ({item, depth = 0}: {item: TOCItem; depth?: number}) => {
+  const hasChildren = item.children && item.children.length > 0
+
+  if (!hasChildren) {
+    return (
+      <div style={{paddingLeft: depth * 24 + 20, padding: '8px 0 8px ' + (depth * 24 + 20) + 'px'}}>
+        {item.hasText ? (
+          <Link to={questionUrl(item)} className="teal-500">
+            {item.title}
+          </Link>
+        ) : (
+          <span>{item.title}</span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <details open style={{paddingLeft: depth * 24}}>
+      <summary
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          cursor: 'pointer',
+          padding: '8px 0',
+          listStyle: 'none',
+        }}
+      >
+        <Chevron />
+        {item.hasText ? (
+          <Link to={questionUrl(item)} className="teal-500" onClick={(e) => e.stopPropagation()}>
+            {item.title}
+          </Link>
+        ) : (
+          <span>{item.title}</span>
+        )}
+      </summary>
+      {item.children!.map((child) => (
+        <ArticleTree key={child.pageid} item={child} depth={depth + 1} />
+      ))}
+    </details>
+  )
+}
+
+const Section = ({category, toc}: {category: Category; toc: TOCItem[]}) => {
+  const items = toc.filter((item) => item.category === category)
+  if (items.length === 0) return null
+  return (
+    <details open style={{marginBottom: 24}}>
+      <summary
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          cursor: 'pointer',
+          padding: '8px 0',
+          listStyle: 'none',
+        }}
+      >
+        <Chevron />
+        <h2 style={{margin: 0}}>{category} sections</h2>
+      </summary>
+      {items.map((item) => (
+        <ArticleTree key={item.pageid} item={item} depth={1} />
+      ))}
+    </details>
+  )
+}
+
+export default function AllArticles() {
+  const {data} = useLoaderData<ReturnType<typeof loader>>()
+  const {toc, visible} = data
+
+  const tocPageIds = collectPageIds(toc)
+  const otherArticles = visible
+    .filter((item) => !tocPageIds.has(item.pageid))
+    .sort((a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()))
+
+  return (
+    <Page>
+      <main>
+        <div className="article-container" style={{flexDirection: 'column', maxWidth: 800}}>
+          <h1 className="padding-bottom-8">All Articles</h1>
+          <div className="padding-bottom-32 grey">{visible.length} articles</div>
+
+          <Section category={BASIC} toc={toc} />
+          <Section category={ADVANCED} toc={toc} />
+
+          {otherArticles.length > 0 && (
+            <details open style={{marginBottom: 24}}>
+              <summary
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  cursor: 'pointer',
+                  padding: '8px 0',
+                  listStyle: 'none',
+                }}
+              >
+                <Chevron />
+                <h2 style={{margin: 0}}>Other articles</h2>
+              </summary>
+              {otherArticles.map((item) => (
+                <ArticleTree key={item.pageid} item={item} depth={1} />
+              ))}
+            </details>
+          )}
+        </div>
+      </main>
+    </Page>
+  )
+}

--- a/app/routes/articles.tsx
+++ b/app/routes/articles.tsx
@@ -108,8 +108,12 @@ export default function AllArticles() {
   const {toc, visible} = data
 
   const tocPageIds = collectPageIds(toc)
-  const otherArticles = visible
-    .filter((item) => !tocPageIds.has(item.pageid))
+  const others = visible.filter((item) => !tocPageIds.has(item.pageid))
+  const otherChildIds = collectPageIds(
+    others.filter((item) => item.children && item.children.length > 0)
+  )
+  const otherArticles = others
+    .filter((item) => item.children?.length || !otherChildIds.has(item.pageid))
     .sort((a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()))
 
   return (

--- a/app/routesMapper.ts
+++ b/app/routesMapper.ts
@@ -31,6 +31,7 @@ export const questionUrl = ({pageid, title}: {pageid: string; title?: string}) =
 
 export const tagUrl = ({tagId, name}: {tagId?: number | string; name: string}) =>
   tagId ? `/categories/${tagId}/${name}` : `/categories/${name}`
+export const articlesUrl = () => `/articles`
 export const tagsUrl = () => `/categories/`
 export const allTagsUrl = () => `/categories/all`
 


### PR DESCRIPTION
Fix https://github.com/StampyAI/stampy-ui/issues/1043

New /articles page showing all site articles organized by Basic sections, Advanced sections, and Other articles in an expandable tree layout. Adds "Browse all articles" button to the Articles dropdown.

Here are screenshots, but go to the page on the branch to test it out
<img width="1164" height="710" alt="image" src="https://github.com/user-attachments/assets/c8d7fdd0-6988-4edb-aa92-48e74c89493e" />

<img width="928" height="851" alt="image" src="https://github.com/user-attachments/assets/af57e549-4d39-4952-8f51-860ed2514590" />

I also notice that there are a bunch of orphaned articles at the bottom, might be worth cleaning some of them out.

Don't merge until there is a more thorough review.